### PR TITLE
Removing all dependencies of 'castor' lib

### DIFF
--- a/src/main/dist/configuration/silverpeas/00-SilverpeasSettings.xml
+++ b/src/main/dist/configuration/silverpeas/00-SilverpeasSettings.xml
@@ -119,17 +119,7 @@
       <parameter key="IsToolsVisible">true</parameter>
     </configfile>
 
-    <configfile name="workflow/engine/castorSettings.properties">
-      <parameter key="CastorJDOFastDatabaseFileURL">
-        ${SILVERPEAS_HOME}/resources/instanceManager/fast_database.xml
-      </parameter>
-      <parameter key="CastorJDODatabaseFileURL">
-        ${SILVERPEAS_HOME}/resources/instanceManager/database.xml
-      </parameter>
-      <parameter key="CastorJDOLogFileURL">${SILVERPEAS_LOG}/castor.log</parameter>
-      <parameter key="CastorXMLMappingFileURL">
-        ${SILVERPEAS_HOME}/resources/modelManager/mapping.xml
-      </parameter>
+    <configfile name="workflow/engine/settings.properties">
       <parameter key="ProcessModelDir">${SILVERPEAS_DATA_HOME}/workflowRepository/</parameter>
     </configfile>
 


### PR DESCRIPTION
Using JAXB and JPA instead of Castor.
This concerns Silverpeas import/export and workflow functionnalities.

Do not forget to process PR on Silverpeas-Core, Silverpeas-Components and Silverpeas-dependencies-bom.