### PR TITLE
Feature #9290

### DIFF
--- a/src/main/dist/configuration/silverpeas/01-schedulerSettings.groovy
+++ b/src/main/dist/configuration/silverpeas/01-schedulerSettings.groovy
@@ -1,0 +1,30 @@
+/**
+ * This script configures the JDBC dialect to use by the Quartz scheduler when persisting the
+ * jobs and the triggers into a JDBC store.
+ * @author mmoquillon
+ */
+
+log.info 'Configure the JDBC driver delegate for the Persistent Quartz Scheduler'
+
+String driverDelegateClass
+switch (settings.DB_SERVERTYPE) {
+  case 'POSTGRESQL':
+    driverDelegateClass = 'org.quartz.impl.jdbcjobstore.PostgreSQLDelegate'
+    break
+  case 'MSSQL':
+    driverDelegateClass = 'org.quartz.impl.jdbcjobstore.MSSQLDelegate'
+    break
+  case 'ORACLE':
+    driverDelegateClass = 'org.quartz.impl.jdbcjobstore.oracle.OracleDelegate'
+    break
+  default:
+    driverDelegateClass = 'org.quartz.impl.jdbcjobstore.StdJDBCDelegate'
+    break
+}
+
+def properties = ['org.quartz.jobStore.driverDelegateClass': driverDelegateClass]
+
+service.updateProperties(
+    "${settings.SILVERPEAS_HOME}/properties/org/silverpeas/scheduler/settings/persistent-scheduler.properties",
+    properties)
+


### PR DESCRIPTION
Add a new configuration script to select the correct SQL dialect to use by the
Quartz scheduler when persisting the jobs and then triggers into the JDBC store.

**Don't forget to merge before the following PRs:**
- Silverpeas-Core [#855](https://github.com/Silverpeas/Silverpeas-Core/pull/855) in SIlverpeas-Core
- Silverpeas-Components [#563](https://github.com/Silverpeas/Silverpeas-Components/pull/563)
