### PR TITLE
Feature #12832 adding new configuration parameters

### DIFF
--- a/src/main/dist/bin/build.gradle
+++ b/src/main/dist/bin/build.gradle
@@ -152,7 +152,9 @@ task start {
   group 'Silverpeas'
   doLast {
     long timeout = (project.silversetup.settings.SERVER_STARTING_TIMEOUT as Long) * 1000
+    boolean serverManagementAllIP = (project.silversetup.settings.getOrDefault('SERVER_MANAGEMENT_ALL_IP', false).toBoolean())
     new JBossServer(project.silversetup.jbossHome.path)
+        .setServerManagementAllIP(serverManagementAllIP)
         .withStartingTimeout(timeout)
         .redirectOutputTo(project.ext.jbossOutputLog)
         .start()
@@ -168,7 +170,9 @@ task debug {
   doLast {
     int port = (project.ext.has('port') ? project.ext.port as int:5005)
     long timeout = (project.silversetup.settings.SERVER_STARTING_TIMEOUT as Long) * 1000
+    boolean serverManagementAllIP = (project.silversetup.settings.getOrDefault('SERVER_MANAGEMENT_ALL_IP', false).toBoolean())
     new JBossServer(project.silversetup.jbossHome.path)
+        .setServerManagementAllIP(serverManagementAllIP)
         .withStartingTimeout(timeout)
         .redirectOutputTo(project.ext.jbossOutputLog)
         .debug(port)

--- a/src/main/dist/configuration/jboss/jackrabbit-ds.cli
+++ b/src/main/dist/configuration/jboss/jackrabbit-ds.cli
@@ -16,6 +16,7 @@ data-source add \
   --jndi-name=java:/datasources/DocumentStore \
   --jta=false \
   --use-java-context=true \
+  --statistics-enabled=${JCR_STATS_ENABLED} \
   --user-name=${JCR_USER} \
   --password=${JCR_PASSWORD} \
   --use-ccm=true \

--- a/src/main/dist/configuration/jboss/silverpeas-ds.cli
+++ b/src/main/dist/configuration/jboss/silverpeas-ds.cli
@@ -16,6 +16,7 @@ data-source add \
   --jndi-name=${DB_DATASOURCE_JNDI} \
   --allow-multiple-users=true \
   --use-java-context=true \
+  --statistics-enabled=${DB_STATS_ENABLED} \
   --user-name=${DB_USER} \
   --password=${DB_PASSWORD} \
   --use-ccm=true \

--- a/src/main/dist/configuration/sample_config.properties
+++ b/src/main/dist/configuration/sample_config.properties
@@ -93,6 +93,13 @@
 # change the value here (for example, by setting it to 900 for 15mn)
 #SERVER_STARTING_TIMEOUT = 300
 
+# By default, the management console is only available on the machine of the running wildfly
+# at IP 127.0.0.1 and port 9990.
+# This variable allows the management console to be accessible from any server IP. This is useful
+# with a client server which does not provide WEB browser (which is generally the case).
+# By default, false (that means default wildfly behavior).
+#SERVER_MANAGEMENT_ALL_IP = false
+
 ####################################################################################################
 ## Properties of the database to use for Silverpeas.
 ####################################################################################################
@@ -129,6 +136,7 @@
 #DB_MAX_POOL_SIZE=120
 #DB_IDLE_TIMEOUT=15
 #DB_BLOCKING_TIMEOUT=30000
+#DB_STATS_ENABLED=false
 
 ####################################################################################################
 ## Properties for the JCR used by Silverpeas to store document metadata.
@@ -148,6 +156,7 @@
 #JCR_MAX_POOL_SIZE=55
 #JCR_IDLE_TIMEOUT=15
 #JCR_BLOCKING_TIMEOUT=30000
+#JCR_STATS_ENABLED=false
 
 ####################################################################################################
 ## Document Conversion Service properties.


### PR DESCRIPTION
Adding parameter JCR_STATS_ENABLED and DB_STATS_ENABLED in order to enable the statistics on Silverpeas's used data sources. When statistics enabled on a data source, its pool state can be analyzed in real time from management console.

Adding boolean SERVER_MANAGEMENT_ALL_IP parameter which allows to enable the management services access from server IP and not only localhost. This is useful with Silverpeas's servers not providing WEB browsers.

Linked to PR https://github.com/Silverpeas/Silverpeas-Setup/pull/26